### PR TITLE
ops: decrease replicas db

### DIFF
--- a/manifests/postgres-databases/db-applet.yaml
+++ b/manifests/postgres-databases/db-applet.yaml
@@ -3,7 +3,7 @@ kind: Cluster
 metadata:
   name: db-applet
 spec:
-  instances: 3
+  instances: 2
 
   storage:
     size: 1Gi


### PR DESCRIPTION
This PR decreases the number of replicas of the `db-applet` from 3 to 2.