### PR TITLE
ops: add k8s netpol for all apps

### DIFF
--- a/argocd/network-policies.yaml
+++ b/argocd/network-policies.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: network-policies
+  namespace: argocd
+  finalizers:
+    - argoproj.io/resources-finalizer
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/Lincon-Freitas/devops-tech-challenge
+    targetRevision: HEAD
+    path: manifests/network-policies/
+    directory:
+      recurse: true
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: todo-list
+  syncPolicy:
+    automated:
+      selfHeal: true
+      prune: false
+    syncOptions:
+      - CreateNamespace=true

--- a/manifests/network-policies/be-applet.yaml
+++ b/manifests/network-policies/be-applet.yaml
@@ -1,0 +1,30 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: be-applet
+  namespace: todo-list
+spec:
+  podSelector:
+    matchLabels:
+      app: be-applet
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+    - ports:
+      - protocol: TCP
+        port: 8000
+  egress:
+    - to:
+      - podSelector:
+          matchLabels:
+            app: db-applet
+      ports:
+        - protocol: TCP
+          port: 5432
+  
+    - ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53

--- a/manifests/network-policies/db-applet.yaml
+++ b/manifests/network-policies/db-applet.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: db-applet
+  namespace: todo-list
+spec:
+  podSelector:
+    matchLabels:
+      app: db-applet
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+    - from:
+      - podSelector:
+          matchLabels:
+            app: be-applet
+      ports:
+        - protocol: TCP
+          port: 5432
+

--- a/manifests/network-policies/fe-applet.yaml
+++ b/manifests/network-policies/fe-applet.yaml
@@ -1,0 +1,30 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: fe-applet
+  namespace: todo-list
+spec:
+  podSelector:
+    matchLabels:
+      app: fe-applet
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+    - ports:
+      - protocol: TCP
+        port: 3000
+  egress:
+    - to:
+      - podSelector:
+          matchLabels:
+            app: fe-applet
+      ports:
+        - protocol: TCP
+          port: 8000
+  
+    - ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53


### PR DESCRIPTION
This PR adds the Kubernetes Network Policies and an ArgoCD Application to manage these resource types.