### PR TITLE
fix: fe netpol label

### DIFF
--- a/manifests/network-policies/fe-applet.yaml
+++ b/manifests/network-policies/fe-applet.yaml
@@ -18,7 +18,7 @@ spec:
     - to:
       - podSelector:
           matchLabels:
-            app: fe-applet
+            app: be-applet
       ports:
         - protocol: TCP
           port: 8000


### PR DESCRIPTION
This PR fixes a typo in the `fe-applet` netpol preventing it from accessing `be-applet`.