### PR TITLE
fix: startup probes

### DIFF
--- a/apps/backend/values.yaml
+++ b/apps/backend/values.yaml
@@ -36,14 +36,6 @@ resources:
     cpu: 100m
     memory: 128Mi
 
-startupProbe:
-  httpGet:
-    host: db-applet-rw
-    path: /
-    port: 80
-  failureThreshold: 24
-  periodSeconds: 5
-
 autoscaling:
   enabled: false
 

--- a/apps/backend/values.yaml
+++ b/apps/backend/values.yaml
@@ -48,9 +48,7 @@ topologySpreadConstraints:
   maxSkew: 1
 
 configMap:
-  enabled: true
-  data:
-    DATABASE_URL: "$(uri)"
+  enabled: false
 
 secret:
   enabled: false

--- a/apps/backend/values.yaml
+++ b/apps/backend/values.yaml
@@ -62,3 +62,8 @@ env:
       secretKeyRef:
         name: db-applet-app
         key: uri
+
+initContainers:
+  - name: check-db-applet
+    image: busybox:stable
+    command: ['sh', '-c', 'until nc -z db-applet-rw 5432; do echo "waiting for database...""; sleep 2; done']

--- a/apps/frontend/values.yaml
+++ b/apps/frontend/values.yaml
@@ -53,7 +53,7 @@ configMap:
     REACT_APP_BACKEND_API_BASE_URL: "http://todo-api.apps.127.0.0.1.nip.io"
 
 initContainers:
-  - name: check-db-applet
+  - name: check-be-applet
     image: busybox:stable
     command: ['sh', '-c', 'until nc -z be-applet 80; do echo "waiting for backend...""; sleep 2; done']
 

--- a/apps/frontend/values.yaml
+++ b/apps/frontend/values.yaml
@@ -36,14 +36,6 @@ resources:
     cpu: 100m
     memory: 512Mi
 
-startupProbe:
-  httpGet:
-    host: be-applet
-    path: /
-    port: 80
-  failureThreshold: 24
-  periodSeconds: 5
-
 autoscaling:
   enabled: false
 

--- a/apps/frontend/values.yaml
+++ b/apps/frontend/values.yaml
@@ -51,3 +51,9 @@ configMap:
   enabled: true
   data:
     REACT_APP_BACKEND_API_BASE_URL: "http://todo-api.apps.127.0.0.1.nip.io"
+
+initContainers:
+  - name: check-db-applet
+    image: busybox:stable
+    command: ['sh', '-c', 'until nc -z be-applet 80; do echo "waiting for backend...""; sleep 2; done']
+

--- a/helm-chart/templates/deployment.yaml
+++ b/helm-chart/templates/deployment.yaml
@@ -72,10 +72,6 @@ spec:
           readinessProbe:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.startupProbe }}
-          startupProbe:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
           {{- with .Values.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/helm-chart/templates/deployment.yaml
+++ b/helm-chart/templates/deployment.yaml
@@ -80,6 +80,10 @@ spec:
           volumeMounts:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+      {{- with .Values.initContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.volumes }}
       volumes:
         {{- toYaml . | nindent 8 }}

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -87,7 +87,7 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
-# This is to setup the liveness, readiness and startup probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+# This is to setup the liveness and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
 livenessProbe:
   httpGet:
     path: /
@@ -96,7 +96,6 @@ readinessProbe:
   httpGet:
     path: /
     port: http
-startupProbe: {}
 
 # This section is for setting up autoscaling more information can be found here: https://kubernetes.io/docs/concepts/workloads/autoscaling/
 autoscaling:

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -153,3 +153,6 @@ env:
 #      secretKeyRef:
 #        name: bar
 #        key: foobar
+
+# Add initContainers to the main Deployment: https://kubernetes.io/docs/concepts/workloads/pods/init-containers
+initContainers: {}


### PR DESCRIPTION
This PR remove the `startupProbe` and adds the `initContainer` settings for configuring application startup needs. Initially the implementation is for application dependency checks but it can be extended for further needs. There is also a values change for backend for disabling an unneeded configmap.