### PR TITLE
fix: typo initcontainer fe be

### DIFF
--- a/apps/backend/values.yaml
+++ b/apps/backend/values.yaml
@@ -64,4 +64,4 @@ env:
 initContainers:
   - name: check-db-applet
     image: busybox:stable
-    command: ['sh', '-c', 'until nc -z db-applet-rw 5432; do echo "waiting for database...""; sleep 2; done']
+    command: ['sh', '-c', 'until nc -z db-applet-rw 5432; do echo "waiting for database..."; sleep 2; done']

--- a/apps/frontend/values.yaml
+++ b/apps/frontend/values.yaml
@@ -55,5 +55,5 @@ configMap:
 initContainers:
   - name: check-be-applet
     image: busybox:stable
-    command: ['sh', '-c', 'until nc -z be-applet 80; do echo "waiting for backend...""; sleep 2; done']
+    command: ['sh', '-c', 'until nc -z be-applet 80; do echo "waiting for backend..."; sleep 2; done']
 


### PR DESCRIPTION
This PR fixes a typo in the `initContainer` command.