### PR TITLE
ops: disable unused external-secrets-operator crds

### DIFF
--- a/apps/external-secrets-operator/values.yaml
+++ b/apps/external-secrets-operator/values.yaml
@@ -1,0 +1,6 @@
+crds:
+  createClusterExternalSecret: false
+  createClusterSecretStore: false
+  createClusterGenerator: false
+  createClusterPushSecret: false
+  createPushSecret: false

--- a/argocd/external-secrets-operator.yaml
+++ b/argocd/external-secrets-operator.yaml
@@ -13,7 +13,8 @@ spec:
     targetRevision: 0.19.1
     helm:
       releaseName: external-secrets
-
+      valueFiles:
+      - ../apps/external-secrets-operator/values.yaml
   destination:
     server: https://kubernetes.default.svc
     namespace: external-secrets


### PR DESCRIPTION
This PR adds a few values to External Secrets Operator to remove unused CRDs.