### PR TITLE
ops: add sync replace for external-secrets-operator

### DIFF
--- a/apps/external-secrets-operator/values.yaml
+++ b/apps/external-secrets-operator/values.yaml
@@ -1,6 +1,0 @@
-crds:
-  createClusterExternalSecret: false
-  createClusterSecretStore: false
-  createClusterGenerator: false
-  createClusterPushSecret: false
-  createPushSecret: false

--- a/argocd/external-secrets-operator.yaml
+++ b/argocd/external-secrets-operator.yaml
@@ -13,12 +13,6 @@ spec:
     targetRevision: 0.19.1
     helm:
       releaseName: external-secrets
-      valueFiles:
-      - $values/apps/external-secrets-operator/values.yaml
-
-  - repoURL: https://github.com/Lincon-Freitas/devops-tech-challenge
-    targetRevision: HEAD
-    ref: values
 
   destination:
     server: https://kubernetes.default.svc
@@ -29,3 +23,4 @@ spec:
       prune: false
     syncOptions:
       - CreateNamespace=true
+      - Replace=true


### PR DESCRIPTION
This PR removes unecessary values and enable `Replace=true` ArgoCD sync option for External Secrets Operator. This fixes the [annotation too big](https://argo-cd.readthedocs.io/en/release-2.3/user-guide/sync-options/#replace-resource-instead-of-applying-changes) issue on CRDs.