### PR TITLE
ops: remove cert & webhook controlers from eso

### DIFF
--- a/apps/external-secrets-operator/values.yaml
+++ b/apps/external-secrets-operator/values.yaml
@@ -1,0 +1,4 @@
+certController:
+  create: false
+webhook:
+  create: false

--- a/argocd/external-secrets-operator.yaml
+++ b/argocd/external-secrets-operator.yaml
@@ -13,6 +13,12 @@ spec:
     targetRevision: 0.19.1
     helm:
       releaseName: external-secrets
+      valueFiles:
+      - $values/apps/external-secrets-operator/values.yaml
+
+  - repoURL: https://github.com/Lincon-Freitas/devops-tech-challenge
+    targetRevision: HEAD
+    ref: values
 
   destination:
     server: https://kubernetes.default.svc


### PR DESCRIPTION
Add ESO values file to disable Cert and Webhook controllers. This will make the enviroment deploy smoother (this is fine since it is not a production deployment).