### PR TITLE
fix: postgres service name

### DIFF
--- a/apps/backend/values.yaml
+++ b/apps/backend/values.yaml
@@ -54,4 +54,4 @@ secret:
 initContainers:
   - name: check-db-applet
     image: busybox:stable
-    command: ['sh', '-c', 'until nc -z db-applet-rw 5432; do echo "waiting for database..."; sleep 2; done']
+    command: ['sh', '-c', 'until nc -z postgres-postgresql 5432; do echo "waiting for database..."; sleep 2; done']

--- a/manifests/external-secrets/secret.yaml
+++ b/manifests/external-secrets/secret.yaml
@@ -13,7 +13,7 @@ spec:
     template:
       engineVersion: v2
       data: 
-        DATABASE_URL: 'postgresql://postgres:{{ .postgres_password }}@postgres:5432/postgres'
+        DATABASE_URL: 'postgresql://postgres:{{ .postgres_password }}@postgres-postgresql:5432/postgres'
   data:
   - secretKey: postgres_password
     remoteRef:


### PR DESCRIPTION
This PR fixes the Postgres service name configuration in both the ExternalSecret and be initcontainer verification.