### PR TITLE
ops: add metrics-server

### DIFF
--- a/apps/metrics-server/values.yaml
+++ b/apps/metrics-server/values.yaml
@@ -1,0 +1,3 @@
+args:
+  - --kubelet-insecure-tls
+  - --kubelet-preferred-address-types=InternalIP,Hostname

--- a/argocd/metrics-server.yaml
+++ b/argocd/metrics-server.yaml
@@ -1,0 +1,29 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: metrics-server
+  namespace: argocd
+  finalizers:
+    - argoproj.io/resources-finalizer
+spec:
+  project: default
+  sources:
+  - chart: metrics-server
+    repoURL: https://kubernetes-sigs.github.io/metrics-server
+    targetRevision: 3.13.0
+    helm:
+      releaseName: metrics-server
+      valueFiles:
+      - $values/apps/metrics-server/values.yaml
+
+  - repoURL: https://github.com/Lincon-Freitas/devops-tech-challenge
+    targetRevision: HEAD
+    ref: values
+
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kube-system
+  syncPolicy:
+    automated:
+      selfHeal: true
+      prune: false


### PR DESCRIPTION
This PR adds `metrics-server` Helm Chart for enabling metrics e.g. for HPA.