### PR TITLE
Ops/add argocd sync wave postgres

### DIFF
--- a/apps/postgres/values.yaml
+++ b/apps/postgres/values.yaml
@@ -1,5 +1,7 @@
 commonLabels:
   app: db-applet
+commonAnnotations:
+  argocd.argoproj.io/sync-wave: "-1"
 primary:
   persistence:
     size: 1Gi

--- a/argocd/postgres.yaml
+++ b/argocd/postgres.yaml
@@ -10,7 +10,7 @@ spec:
   sources:
   - chart: postgresql
     repoURL: https://charts.bitnami.com/bitnami
-    targetRevision: 16.7.20
+    targetRevision: 16.7.24
     helm:
       releaseName: postgres
       valueFiles:


### PR DESCRIPTION
This PR adds ArgoCD sync-waves annotations to Porstgres resources to ensure it is deployed first. Alsp bumps a minor version of the Helm Chart.