### PR TITLE
ops: define postgres static secret

### DIFF
--- a/apps/postgres/values.yaml
+++ b/apps/postgres/values.yaml
@@ -1,3 +1,7 @@
+global:
+  postgresql:
+    auth:
+      postgresPassword: "ByKaKHKpZK"
 commonLabels:
   app: db-applet
 primary:

--- a/argocd/postgres.yaml
+++ b/argocd/postgres.yaml
@@ -3,8 +3,6 @@ kind: Application
 metadata:
   name: postgres
   namespace: argocd
-  annotations:
-    argocd.argoproj.io/sync-wave: "-1"
   finalizers:
     - argoproj.io/resources-finalizer
 spec:


### PR DESCRIPTION
This PR adds a static password setting for Postgres. The auto generated passwords seem to not work 100% of the times and for this tests purposes this should be fine. ArgoCD sync-wave is not needed anymore for ordering the applications so it's been removed.