### PR TITLE
ops: disable postgres default netpol

### DIFF
--- a/apps/postgres/values.yaml
+++ b/apps/postgres/values.yaml
@@ -5,5 +5,7 @@ global:
 commonLabels:
   app: db-applet
 primary:
+  networkPolicy:
+    enabled: false
   persistence:
     size: 1Gi


### PR DESCRIPTION
This PR disables the default Network Policy created by the Postgres Helm Chart so we have a clean set of defined policies.